### PR TITLE
arbitrary map of tags for generated resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -329,7 +329,7 @@ resource "azurerm_public_ip" "secondary_external_public_ip" {
   allocation_method = "Static"   # Static is required due to the use of the Standard sku
   sku               = "Standard" # the Standard sku is required due to the use of availability zones
   availability_zone = var.availabilityZones_public_ip
-  tags = merge(loca.tags,{
+  tags = merge(local.tags,{
     Name   = format("%s-secondary-pip-ext-%s", local.instance_prefix, count.index)
   }
   )

--- a/main.tf
+++ b/main.tf
@@ -164,7 +164,11 @@ locals {
   instance_prefix = format("%s-%s", var.prefix, random_id.module_id.hex)
   gw_bytes_nic    = local.total_nics > 1 ? element(split("/", local.selfip_list[0]), 0) : ""
 
-
+  tags = merge(var.tags,{ 
+    Prefix = format("%s", local.instance_prefix)
+    source = "terraform"
+    }
+  )
 }
 
 #
@@ -291,10 +295,10 @@ resource "azurerm_public_ip" "mgmt_public_ip" {
   allocation_method   = "Static"   # Static is required due to the use of the Standard sku
   sku                 = "Standard" # the Standard sku is required due to the use of availability zones
   availability_zone   = var.availabilityZones_public_ip
-  tags = {
+  tags = merge(local.tags,{
     Name   = format("%s-pip-mgmt-%s", local.instance_prefix, count.index)
-    source = "terraform"
   }
+  )
 }
 
 resource "azurerm_public_ip" "external_public_ip" {
@@ -308,10 +312,10 @@ resource "azurerm_public_ip" "external_public_ip" {
   allocation_method = "Static"   # Static is required due to the use of the Standard sku
   sku               = "Standard" # the Standard sku is required due to the use of availability zones
   availability_zone = var.availabilityZones_public_ip
-  tags = {
+  tags = merge(local.tags,{
     Name   = format("%s-pip-ext-%s", local.instance_prefix, count.index)
-    source = "terraform"
   }
+  )
 }
 
 resource "azurerm_public_ip" "secondary_external_public_ip" {
@@ -325,10 +329,10 @@ resource "azurerm_public_ip" "secondary_external_public_ip" {
   allocation_method = "Static"   # Static is required due to the use of the Standard sku
   sku               = "Standard" # the Standard sku is required due to the use of availability zones
   availability_zone = var.availabilityZones_public_ip
-  tags = {
+  tags = merge(loca.tags,{
     Name   = format("%s-secondary-pip-ext-%s", local.instance_prefix, count.index)
-    source = "terraform"
   }
+  )
 }
 
 # Deploy BIG-IP with N-Nic interface 
@@ -346,10 +350,10 @@ resource "azurerm_network_interface" "mgmt_nic" {
     private_ip_address            = (length(local.mgmt_public_private_ip_primary[count.index]) > 0 ? local.mgmt_public_private_ip_primary[count.index] : null)
     public_ip_address_id          = local.bigip_map["mgmt_subnet_ids"][count.index]["public_ip"] ? azurerm_public_ip.mgmt_public_ip[count.index].id : ""
   }
-  tags = {
+  tags = merge(local.tags,{
     Name   = format("%s-mgmt-nic-%s", local.instance_prefix, count.index)
-    source = "terraform"
   }
+  )
 }
 
 resource "azurerm_network_interface" "external_nic" {
@@ -373,10 +377,10 @@ resource "azurerm_network_interface" "external_nic" {
     private_ip_address_allocation = (length(local.external_private_ip_secondary[count.index]) > 0 ? "Static" : "Dynamic")
     private_ip_address            = (length(local.external_private_ip_secondary[count.index]) > 0 ? local.external_private_ip_secondary[count.index] : null)
   }
-  tags = {
+  tags = merge(local.tags,{
     Name   = format("%s-ext-nic-%s", local.instance_prefix, count.index)
-    source = "terraform"
   }
+  )
 }
 
 resource "azurerm_network_interface" "external_public_nic" {
@@ -401,10 +405,10 @@ resource "azurerm_network_interface" "external_public_nic" {
     private_ip_address            = (length(local.external_public_private_ip_secondary[count.index]) > 0 ? local.external_public_private_ip_secondary[count.index] : null)
     public_ip_address_id          = azurerm_public_ip.secondary_external_public_ip[count.index].id
   }
-  tags = {
+  tags = merge(local.tags,{
     Name   = format("%s-ext-public-nic-%s", local.instance_prefix, count.index)
-    source = "terraform"
   }
+  )
 }
 
 resource "azurerm_network_interface" "internal_nic" {
@@ -421,10 +425,10 @@ resource "azurerm_network_interface" "internal_nic" {
     private_ip_address            = (length(local.internal_private_ip_primary[count.index]) > 0 ? local.internal_private_ip_primary[count.index] : null)
     //public_ip_address_id          = length(azurerm_public_ip.mgmt_public_ip.*.id) > count.index ? azurerm_public_ip.mgmt_public_ip[count.index].id : ""
   }
-  tags = {
+  tags = merge(local.tags,{
     Name   = format("%s-internal-nic-%s", local.instance_prefix, count.index)
-    source = "terraform"
   }
+  )
 }
 
 resource "azurerm_network_interface_security_group_association" "mgmt_security" {
@@ -511,10 +515,10 @@ resource "azurerm_virtual_machine" "f5vm01" {
     product   = var.f5_product_name
   }
   zones = var.availabilityZones
-  tags = {
+  tags = merge(local.tags,{
     Name   = format("%s-f5vm01", local.instance_prefix)
-    source = "terraform"
   }
+  )
   identity {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.user_identity.id]

--- a/variables.tf
+++ b/variables.tf
@@ -209,3 +209,9 @@ variable custom_user_data {
   type        = string
   default     = null
 }
+
+variable tags {
+  description = "key:value tags to apply to resources built by the module"
+  type        = map
+  default     = {}
+}


### PR DESCRIPTION
Add an input variable "tags" to pass in key-value pairs as a map. The tags are applied to all resources generated by the module. The map of tags is merged with any existing resource-specific tags (e.g. Name). The input variable has a default value of an empty map (i.e. '{]' )

This PR has been successfully tested without the tags input variable and with a set of arbitrary key-value pairs to build a BIG-IP with TMOS 16.1.0.

Profile: BIG-IP Automation Toolchain readiness (bigip-ready)
Version: 0.1.0
Target:  local://

  ✔  bigip-connectivity: BIG-IP is reachable
     ✔  Host x.x.x.x port 443 proto tcp is expected to be reachable
  ✔  bigip-declarative-onboarding: BIG-IP has Declarative Onboarding
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/declarative-onboarding/info status is expected to cmp == 200
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/declarative-onboarding/info headers.Content-Type is expected to match "application/json"
  ✔  bigip-declarative-onboarding-version: BIG-IP has specified version of Declarative Onboarding
     ✔  JSON content [0, "version"] is expected to eq "1.21.0"
  ✔  bigip-application-services: BIG-IP has Application Services
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/appsvcs/info status is expected to cmp == 200
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/appsvcs/info headers.Content-Type is expected to match "application/json"
  ✔  bigip-application-services-version: BIG-IP has specified version of Application Services
     ✔  JSON content version is expected to eq "3.28.0"
  ✔  bigip-telemetry-streaming: BIG-IP has Telemetry Streaming
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/telemetry/info status is expected to cmp == 200
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/telemetry/info headers.Content-Type is expected to match "application/json"
  ✔  bigip-telemetry-streaming-version: BIG-IP has specified version of Telemetry Streaming
     ✔  JSON content version is expected to eq "1.20.0"
  ✔  bigip-licensed: BIG-IP has an active license
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/tm/sys/license body is expected to match /registrationKey/


Profile: bigip Kitchen-Terraform (bigip)
Version: 0.1.0
Target:  local://

  ✔  bigip-postbuildconfig-do-self: expected selfIps
     ✔  JSON content address is expected to cmp == "10.20.0.9/24"
     ✔  JSON content vlan is expected to cmp == "/Common/external"
     ✔  JSON content allowService is expected to cmp == "tcp:443"
     ✔  JSON content address is expected to cmp == "10.30.0.10/24"
     ✔  JSON content vlan is expected to cmp == "/Common/internal"
     ✔  JSON content allowService is expected to cmp == "default"
  ✔  bigip-postbuildconfig-do-dns: expected dns
     ✔  JSON content nameServers is expected to cmp == "168.63.129.16"
  ✔  bigip-postbuildconfig-do-vlan: expected vlans
     ✔  JSON content tag is expected to cmp == "10"
     ✔  JSON content mtu is expected to cmp == "1500"
     ✔  JSON content tag is expected to cmp == "20"
     ✔  JSON content mtu is expected to cmp == "1500"
  ✔  bigip-postbuildconfig-do-provision: expected provisioning
     ✔  JSON content level is expected to cmp == "nominal"
     ✔  JSON content level is expected to cmp == "nominal"